### PR TITLE
Upgrading IntelliJ from 2023.3 to 2023.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.3 to 2023.3.1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'intellij-code-exfiltration'
 # SemVer format -> https://semver.org
-pluginVersion = 0.4.0
+pluginVersion = 0.4.1
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 0.4.0
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.3,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.3.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `NOT_DYNAMIC` Failure Level because we use an application component (`CodeExfiltrationService`).
 pluginVerifierExcludeFailureLevels = NOT_DYNAMIC
@@ -25,7 +25,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.3
+platformVersion = 2023.3.1
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.3 to 2023.3.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661792/IntelliJ-IDEA-2023.3.1-233.11799.300-build-Release-Notes

# What's New?
<strong>IntelliJ IDEA 2023.3.1 is out with important improvements:</strong> 
<ul> 
 <li>Fixed a bug preventing users from logging in to AI Assistant.</li> 
 <li>Provided the opportunity to check the access status for users with corporate IDE licenses from the<em> AI Assistant</em> tool window.</li> 
</ul> For more details, refer to this 
<a href="https://blog.jetbrains.com/idea/2023/12/intellij-idea-2023-3-1/">blog post</a>. 
<strong>IntelliJ IDEA 2023.3 release highlights:</strong> 
<ul> 
 <li>AI Assistant, which is now out of preview</li> 
 <li>Full support for Java 21</li> 
 <li><em>Run to Cursor</em> inlay option in the debugger</li> 
 <li>Floating toolbar with editing actions</li> 
 <li>Streamlined out-of-the-box Kubernetes development experience</li> 
</ul> Visit our 
<a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> or watch 
<a href="https://youtu.be/zYvfIMrcpt8">this video</a> to learn about these and other improvements.
    