### PR TITLE
Upgrading IntelliJ from 2024.2 to 0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.2 to 0.0.0
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ pluginUntilBuild = 242.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 0.0,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # TODO(ChrisCarini) - `PLUGIN_STRUCTURE_WARNINGS` can be removed once https://youtrack.jetbrains.com/issue/MP-6711 is resolved.
 #  See below for details:
@@ -39,7 +39,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.2
+platformVersion = 0.0
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.2 to 0.0.0

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662094/IntelliJ-IDEA-2024.2.0.2-242.20224.419-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.2.0.2 is out! This update brings a range of valuable fixes and improvements.
    