### PR TITLE
Upgrading IntelliJ from 2024.2.4 to 2024.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.2.4 to 2024.3.0
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,16 +8,16 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/intellij-code-exfiltration
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 1.1.4
+pluginVersion = 1.2.0
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 242
-pluginUntilBuild = 242.*
+pluginSinceBuild = 243
+pluginUntilBuild = 243.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.2.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # TODO(ChrisCarini) - `PLUGIN_STRUCTURE_WARNINGS` can be removed once https://youtrack.jetbrains.com/issue/MP-6711 is resolved.
 #  See below for details:
@@ -39,7 +39,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.2.4
+platformVersion = 2024.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.2.4 to 2024.3.0

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662289/IntelliJ-IDEA-2024.3-243.21565.193-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.3 is out, featuring the following highlights: 
<ul>
 <li><em>Logical</em> code structure view</li>
 <li>Streamlined Kubernetes application debugging</li>
 <li>Cluster-wide Kubernetes log access</li>
 <li>Stable Kotlin K2 mode</li>
</ul> Visit our <a href="https://www.jetbrains.com/idea/whatsnew">What's New page</a> or watch <a href="https://youtu.be/NDBIYcrsC84">this video</a> to learn about these and other improvements.
    