### PR TITLE
Upgrading IntelliJ from 2024.3.4 to 2024.3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.3.4 to 2024.3.4.1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/intellij-code-exfiltration
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 1.2.7
+pluginVersion = 1.2.8
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 243.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.3.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.3.4.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # TODO(ChrisCarini) - `PLUGIN_STRUCTURE_WARNINGS` can be removed once https://youtrack.jetbrains.com/issue/MP-6711 is resolved.
 #  See below for details:
@@ -39,7 +39,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.3.4
+platformVersion = 2024.3.4.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.3.4 to 2024.3.4.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662392/IntelliJ-IDEA-2024.3.4.1-243.25659.59-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.3.4.1 is out! This update brings the following hotfix: 
<ul>
 <li>Import order formatting defined in settings is once again properly preserved. [<a href="https://youtrack.jetbrains.com/issue/IDEA-368382">IDEA-368382</a>]</li>
</ul> For the full details, please refer to the <a href="https://youtrack.jetbrains.com/articles/IDEA-A-2100662392/IntelliJ-IDEA-2024.3.4.1-243.25659.59-build-Release-Notes">release notes</a>.
    