### PR TITLE
Upgrading IntelliJ from 2024.3.4 to 2024.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.3.4 to 2024.3.5
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/intellij-code-exfiltration
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 1.2.7
+pluginVersion = 1.2.8
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 243.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.3.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.3.5,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # TODO(ChrisCarini) - `PLUGIN_STRUCTURE_WARNINGS` can be removed once https://youtrack.jetbrains.com/issue/MP-6711 is resolved.
 #  See below for details:
@@ -39,7 +39,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.3.4
+platformVersion = 2024.3.5
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.3.4 to 2024.3.5

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662405/IntelliJ-IDEA-2024.3.5-243.26053.27-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.3.5 is out with the following improvements: 
<ul>
 <li>The code completion popup once again includes a dropdown menu, allowing for quick access to additional actions and settings. [<a href="https://youtrack.jetbrains.com/issue/IJPL-177749/Disappeared-quick-dropdown-widget-in-completion-popup">IJPL-177749</a>]</li>
 <li>You can now customize the hostname length in <code>HostLabelDropdown</code>, improving usability for infrastructures with longer hostnames. [<a href="https://youtrack.jetbrains.com/issue/IJPL-178086/Add-a-control-handle-to-set-the-max-length-of-the-HostLabelDropdown">IJPL-178086</a>]</li>
 <li>Breakpoints in Dart code can once again be set and hit. [<a href="https://youtrack.jetbrains.com/issue/IDEA-367839/Breakpoints-dont-hit-in-dart-code-if-using-Dart-SDK-2.13.4">IDEA-367839</a>]</li>
</ul> Get more details in our <a href="https://blog.jetbrains.com/idea/2025/03/intellij-idea-2024-3-5/">blog post</a>.
    