### PR TITLE
Upgrading IntelliJ from 2026.1.4 to 2026.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [3.0.2] - 2026-05-16
 
 ### Changed
+- Upgrading IntelliJ from 2026.1.4 to 2026.2
 - Upgrading IntelliJ from 2026.1.3 to 2026.1.4
 - Upgrading IntelliJ from 2026.1.2 to 2026.1.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,16 +8,16 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/intellij-code-exfiltration
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 3.0.4
+pluginVersion = 3.1.0
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 261
-pluginUntilBuild = 261.*
+pluginSinceBuild = 262
+pluginUntilBuild = 262.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2026.1.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2026.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # TODO(ChrisCarini) - `PLUGIN_STRUCTURE_WARNINGS` can be removed once https://youtrack.jetbrains.com/issue/MP-6711 is resolved.
 #  See below for details:
@@ -37,7 +37,7 @@ pluginVerifierMutePluginProblems = TemplateWordInPluginName
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2026.1.4
+platformVersion = 2026.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2026.1.4 to 2026.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662707

# What's New?
<p>IntelliJ IDEA 2026.2 is now out! The highlights of this release include:</p>
<p>AI upgrades:</p>
<ul>
 <li>Native GitHub Copilot integration</li>
 <li>Agent skills</li>
 <li>AI completion support for third-party providers</li>
</ul>
<p>Productivity-enhancing features:</p>
<ul>
 <li>Logpoints</li>
 <li>Dependency completion</li>
 <li>Early Gradle 10 support and migration assistance</li>
 <li>Streamlined Git conflict resolution flow</li>
 <li>Docker Compose improvements</li>
</ul>
<p>Support for new technologies:</p>
<ul>
 <li>Java 27</li>
 <li>Kotlin 2.4 Stable features</li>
 <li>Spring support improvements</li>
 <li>Terraform testing framework</li>
 <li>TypeScript 7.0</li>
</ul>
<p>Visit our <a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> to learn about these and other improvements.</p>
    